### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "nnpack"
+description := "An acceleration package for neural network computations."
+gitrepo     := "https://github.com/Maratyszcza/NNPACK.git"
+homepage    := "https://maratyszcza.github.io/NNPACK/"
+license     := "BSD-2-Clause"
+version     := 24b5530 sha256:1f11dbbfad78d0a4c39fe94e52a28c0821cb25f9880420bb304f6302f73fe002 https://github.com/Maratyszcza/NNPACK/archive/24b5530.tar.gz


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

